### PR TITLE
3.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- ## [[3.1.3](https://github.com/multiversx/mx-sdk-js-webview-provider/pull/30)] - 2025-07-21
+- [Removed `webview` check in `isMobileWebview()`](https://github.com/multiversx/mx-sdk-js-webview-provider/pull/30)
+
 - ## [[3.1.2](https://github.com/multiversx/mx-sdk-js-webview-provider/pull/29)] - 2025-07-04
 - [Update allowedOrigin to be taken from event](https://github.com/multiversx/mx-sdk-js-webview-provider/pull/28)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-webview-provider",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "SDK Webview Provider",
   "main": "out/index.js",
   "types": "out/index.d.js",

--- a/src/helpers/isMobileWebview.ts
+++ b/src/helpers/isMobileWebview.ts
@@ -2,5 +2,6 @@ import { getSafeWindow } from './getSafeWindow';
 
 export const isMobileWebview = () => {
   const safeWindow = getSafeWindow();
-  return safeWindow.ReactNativeWebView || safeWindow.webkit;
+  // webkit removed because of false positive detection on iOS Chrome mobile browser
+  return safeWindow.ReactNativeWebView; // || safeWindow.webkit;
 };


### PR DESCRIPTION
Removed `webview` check in `isMobileWebview()` because of detecting RN iframe context on iPad Chrome