### PR TITLE
Fixed issue with reset callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- ## [[3.2.7](https://github.com/multiversx/mx-sdk-js-webview-provider/pull/46)] - 2026-02-06
+- [Fix webview handshake issue](https://github.com/multiversx/mx-sdk-js-webview-provider/pull/46)
+
 - ## [[3.2.6](https://github.com/multiversx/mx-sdk-js-webview-provider/pull/45)] - 2025-11-24
 - [Update sdk-core imports](https://github.com/multiversx/mx-sdk-js-webview-provider/pull/44)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-webview-provider",
-  "version": "3.2.7-alpha.18",
+  "version": "3.2.7",
   "description": "SDK Webview Provider",
   "main": "out/index.js",
   "types": "out/index.d.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-webview-provider",
-  "version": "3.2.6",
+  "version": "3.2.7-alpha.18",
   "description": "SDK Webview Provider",
   "main": "out/index.js",
   "types": "out/index.d.js",
@@ -10,7 +10,8 @@
   "scripts": {
     "compile": "tsc -p tsconfig.json",
     "pretest": "npm run compile",
-    "prepare": "npm run compile"
+    "prepare": "npm run compile",
+    "publish-verdaccio": "npm run compile && npm publish --registry http://localhost:4873/"
   },
   "author": "MultiversX",
   "license": "MIT",

--- a/src/WebviewProvider.ts
+++ b/src/WebviewProvider.ts
@@ -55,14 +55,9 @@ export class WebviewProvider {
       webviewProviderEventHandler(
         WindowProviderResponseEnums.resetStateResponse,
         (data) => {
-          console.log('resetStateResponse received', data.type);
           if (data.type === WindowProviderResponseEnums.resetStateResponse) {
-            console.log('before finalizeResetState');
             this.finalizeResetState();
-            console.log('after finalizeResetState');
             this.resetStateCallback?.();
-
-            console.log('after resetStateCallback');
             this.initialized = false;
           }
         },
@@ -90,10 +85,6 @@ export class WebviewProvider {
     const safeWindow = getSafeWindow();
     const platform = getPlatform();
 
-    console.log('Init handshake: ', {
-      platform,
-      isInitialized: this.initialized
-    });
     if (platform === PlatformsEnum.WEBVIEW) {
       const handshakePromise = this.sendPostMessage({
         type: WindowProviderRequestEnums.finalizeHandshakeRequest,
@@ -150,7 +141,6 @@ export class WebviewProvider {
     try {
       const { type } = await this.initiateHandshake(version);
 
-      console.log({ type });
       if (type === WindowProviderResponseEnums.finalizeHandshakeResponse) {
         this.initialized = true;
 

--- a/src/WebviewProvider.ts
+++ b/src/WebviewProvider.ts
@@ -36,6 +36,7 @@ export class WebviewProvider {
   private account: IProviderAccount = { address: '' };
   private handshakeResponseTimeout: number = HANDSHAKE_RESPONSE_TIMEOUT;
   private allowedOrigin = '*';
+  private resetStateCallback?: () => void;
 
   static getInstance(options?: IWebviewProviderOptions) {
     if (!WebviewProvider._instance) {
@@ -45,23 +46,24 @@ export class WebviewProvider {
   }
 
   constructor(options?: IWebviewProviderOptions) {
-    if (options?.resetStateCallback) {
-      this.resetState(options.resetStateCallback);
-    }
+    this.resetStateCallback = options?.resetStateCallback;
   }
 
-  private resetState = (resetStateCallback?: () => void) => {
+  private setupResetStateListener = () => {
     getSafeWindow().addEventListener?.(
       'message',
       webviewProviderEventHandler(
         WindowProviderResponseEnums.resetStateResponse,
         (data) => {
+          console.log('resetStateResponse received', data.type);
           if (data.type === WindowProviderResponseEnums.resetStateResponse) {
-            resetStateCallback?.();
+            console.log('before finalizeResetState');
+            this.finalizeResetState();
+            console.log('after finalizeResetState');
+            this.resetStateCallback?.();
 
-            setTimeout(() => {
-              this.finalizeResetState();
-            }, 500);
+            console.log('after resetStateCallback');
+            this.initialized = false;
           }
         },
         this.allowedOrigin
@@ -88,6 +90,10 @@ export class WebviewProvider {
     const safeWindow = getSafeWindow();
     const platform = getPlatform();
 
+    console.log('Init handshake: ', {
+      platform,
+      isInitialized: this.initialized
+    });
     if (platform === PlatformsEnum.WEBVIEW) {
       const handshakePromise = this.sendPostMessage({
         type: WindowProviderRequestEnums.finalizeHandshakeRequest,
@@ -144,8 +150,13 @@ export class WebviewProvider {
     try {
       const { type } = await this.initiateHandshake(version);
 
+      console.log({ type });
       if (type === WindowProviderResponseEnums.finalizeHandshakeResponse) {
         this.initialized = true;
+
+        if (this.resetStateCallback) {
+          this.setupResetStateListener();
+        }
       }
     } catch {
       // No handshake response received


### PR DESCRIPTION
### Summary
- **Fix reset callback flow in webview provider** so that `resetStateCallback` is stored, invoked reliably on reset, and the provider can be re-initialized correctly.
- **Improve observability and versioning** by adding handshake/reset logging and bumping the package to `3.2.7-alpha.18`.

### Changes
- **Store reset callback**: Save `resetStateCallback` on the instance instead of wiring it directly through the constructor.
- **Refactor reset listener**: Introduce `setupResetStateListener` that:
  - Listens for `resetStateResponse`.
  - Immediately calls `finalizeResetState()` when the reset response is received.
  - Invokes the stored `resetStateCallback` after finalizing the reset.
  - Resets `initialized` to `false` so a new handshake can occur cleanly.
- **Handshake flow**:
  - Log initial handshake context (platform and `initialized` state).
  - After a successful `finalizeHandshakeResponse`, mark the provider as initialized and only then set up the reset listener when a `resetStateCallback` is present.
- **Tooling & version**:
  - Bump `package.json` version to `3.2.7-alpha.18`.
  - Add `publish-verdaccio` script for local publishing.

### Rationale
- Previously, the reset logic relied on passing the callback into the listener and used a fixed timeout before calling `finalizeResetState`, which could cause race conditions and unreliable reset behavior.
- The new flow centralizes the callback on the instance, removes arbitrary timing, and tightly couples reset completion with `finalizeResetState`, making the lifecycle easier to reason about and debug.

### Testing
- **Manual**
  - Initialize the webview provider in a webview environment and complete the handshake.
  - Trigger a reset from the host environment and verify:
    - `finalizeResetState` is called once per reset.
    - The provided `resetStateCallback` is invoked exactly once.
    - `initialized` becomes `false` after reset and a subsequent handshake works correctly.
  - Check logs to ensure handshake and reset events are emitted as expected.